### PR TITLE
fix(filter): include signed zero handling; bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "oursum",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"type": "module",
 	"description": "Oursum — personal expense tracker by CarthyWorks",
 	"scripts": {

--- a/src/renderer/hooks/useFilteredTransactions.test.ts
+++ b/src/renderer/hooks/useFilteredTransactions.test.ts
@@ -81,4 +81,16 @@ describe('useFilteredTransactions helpers', () => {
       netBalance: 150,
     });
   });
+
+  test('amountMax = 0 matches expenses (signed <= 0)', () => {
+    const filtered = filterTransactions(transactions, {
+      dateFrom: null,
+      dateTo: null,
+      categories: [],
+      amountMin: null,
+      amountMax: 0,
+    });
+
+    expect(filtered).toEqual([transactions[0], transactions[1]]);
+  });
 });

--- a/src/renderer/hooks/useFilteredTransactions.ts
+++ b/src/renderer/hooks/useFilteredTransactions.ts
@@ -48,6 +48,25 @@ export function filterTransactions(
       return false;
     }
 
+    // Special-case: when user sets a single-sided filter to 0 we interpret
+    // that as "signed" zero bound. E.g. amountMax === 0 should match
+    // transactions with amount <= 0 (expenses), and amountMin === 0 should
+    // match transactions with amount >= 0 (income). This preserves the
+    // existing magnitude-based behavior for other ranges.
+    if (filters.amountMin === null && filters.amountMax === 0) {
+      if (transaction.amount > 0) {
+        return false;
+      }
+      return true;
+    }
+
+    if (filters.amountMax === null && filters.amountMin === 0) {
+      if (transaction.amount < 0) {
+        return false;
+      }
+      return true;
+    }
+
     const absoluteAmount = Math.abs(transaction.amount);
 
     if (filters.amountMin !== null && absoluteAmount < filters.amountMin) {


### PR DESCRIPTION
Fixes bug where filtering by amount <= 0 hid matching entries. Adds test and bumps version to 0.1.1.